### PR TITLE
Fixes #220

### DIFF
--- a/ckanext/odm_theme/plugin.py
+++ b/ckanext/odm_theme/plugin.py
@@ -333,7 +333,7 @@ class OdmThemePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
       facets_dict = {
                 'license_id': toolkit._('License'),
-                'vocab_taxonomy': toolkit._('Topics'),
+                'tags': toolkit._('Topics'),
                 'organization': toolkit._('Organizations'),
                 'groups': toolkit._('Groups'),
                 'res_format': toolkit._('Formats'),
@@ -347,7 +347,7 @@ class OdmThemePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
       group_facets = {
                 'license_id': toolkit._('License'),
-                'vocab_taxonomy': toolkit._('Topics'),
+                'tags': toolkit._('Topics'),
                 'organization': toolkit._('Organizations'),
                 'res_format': toolkit._('Formats'),
                 'odm_language': toolkit._('Language'),
@@ -360,7 +360,7 @@ class OdmThemePlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
       organization_facets = {
                 'license_id': toolkit._('License'),
-                'vocab_taxonomy': toolkit._('Topics'),
+                'tags': toolkit._('Topics'),
                 'groups': toolkit._('Groups'),
                 'res_format': toolkit._('Formats'),
                 'odm_language': toolkit._('Language'),

--- a/ckanext/odm_theme/templates/header.html
+++ b/ckanext/odm_theme/templates/header.html
@@ -130,7 +130,7 @@
           <h4>{{ _('Browse by topic') }}</h4>
           {% for top_topic in h.odm_theme_top_topics() %}
             {% set tag_name = h.odm_theme_tag_for_topic(top_topic) %}
-            <a class="header_tag" href="{% url_for controller='package', action='search', vocab_taxonomy=tag_name %}">{{ h.odm_theme_get_localized_tag(top_topic) }}</a>
+            <a class="header_tag" href="{% url_for controller='package', action='search', tags=tag_name %}">{{ h.odm_theme_get_localized_tag(top_topic) }}</a>
           {% endfor %}
          </div>
          <div class="span3 col2 header-selection">


### PR DESCRIPTION
@chris-aeviator Before, I was using an additional facet to filter datasets by taxonomy (a.k.a topic). But it makes much more sense to use CKAN's built in Tags. The way this works is following:

On the plugin.py file on this CKAN extension, we are telling CKAN that every element on the *taxonomy* metadata field is going to be converted to a tag. See https://github.com/OpenDevelopmentMekong/ckanext-odm_theme/blob/master/ckanext/odm_theme/plugin.py#L439 and https://github.com/OpenDevelopmentMekong/ckanext-odm_theme/blob/master/ckanext/odm_theme/plugin.py#L463

On the pages with lists of datasets, on the left sidebar, the different facets (also customized by the plugin on https://github.com/OpenDevelopmentMekong/ckanext-odm_theme/blob/master/ckanext/odm_theme/plugin.py#L332 are presented. The **topics** facets should be generated from the elements in the **taxonomy** metadata field.

Please review and merge into master if you agree. Please, add comments/questions here if you dont :+1: 